### PR TITLE
Update UUID dependency for deep requiring

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,14 +32,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const LocalMain = __importStar(require("@getflywheel/local/main"));
-const v4_1 = __importDefault(require("uuid/v4"));
+const uuid_1 = require("uuid");
 const addWorkspaceJSON_1 = __importDefault(require("./helpers/addWorkspaceJSON"));
 const enableXDebugPHPini_1 = __importDefault(require("./helpers/enableXDebugPHPini"));
 function default_1(context) {
     const { notifier, electron } = context;
     electron.ipcMain.on('add-vscode-xdebug-config', (event, siteId) => __awaiter(this, void 0, void 0, function* () {
         const site = LocalMain.SiteData.getSite(siteId);
-        const serverUuid = v4_1.default();
+        const serverUuid = uuid_1.v4();
         try {
             yield addWorkspaceJSON_1.default(site, serverUuid);
             yield enableXDebugPHPini_1.default(site, serverUuid);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as Local from '@getflywheel/local';
 import * as LocalMain from '@getflywheel/local/main';
-import uuidv4 from 'uuid/v4';
+import {v4 as uuidv4} from 'uuid';
 import addWorkspaceJSON from './helpers/addWorkspaceJSON';
 import enableXDebugPHPini from './helpers/enableXDebugPHPini';
 


### PR DESCRIPTION
Deep requiring is no longer supported in the UUID library as of v7.  Update dependency syntax to fix.  (#26)